### PR TITLE
Allow relocating the signed RPM to a different path

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,11 @@ aws secretsmanager create-secret --name gpg_passphrase --secret-binary file:///p
 - Create the lambda with the `Go 1.x` runtime, upload the zip archive created above and set the following environment variables:
   - `LAMBDA_SECRET_GPG_KEY`: The name you used for the gpg private key aws secret, e.g. `gpg_key` in the example above
   - `LAMBDA_SECRET_GPG_PASSPHRASE`: The name you used for the gpg passphrase aws secret, e.g. `gpg_passphrase` in the example above
-  - `LAMBDA_S3_TARGET`: the name of your target bucket
-  - `LAMBDA_S3_TARGET_PATH`: (optional) The base path in your target bucket. If set, will replace the path of the rpm to sign. This
-    allows to upload the resulting signed rpm in the same bucket.
+  - `LAMBDA_S3_TARGET`: (optional) The name of the bucket where the signed RPM will be uploaded. If unset, will use the same bucket
+     as the triggering event. Please note that either one of `LAMBDA_S3_TARGET` and `LAMBDA_S3_TARGET_PATH` (or both) need to be set.
+  - `LAMBDA_S3_TARGET_PATH`: (optional) The base path in your target bucket. If set, will replace the path of the RPM to sign. This
+    allows to upload the resulting signed RPM in the same bucket as the unsigned one.
+
 ### create-repo-metadata
 
 TBD

--- a/README.md
+++ b/README.md
@@ -155,9 +155,11 @@ aws secretsmanager create-secret --name gpg_passphrase --secret-binary file:///p
 - Create the lambda with the `Go 1.x` runtime, upload the zip archive created above and set the following environment variables:
   - `LAMBDA_SECRET_GPG_KEY`: The name you used for the gpg private key aws secret, e.g. `gpg_key` in the example above
   - `LAMBDA_SECRET_GPG_PASSPHRASE`: The name you used for the gpg passphrase aws secret, e.g. `gpg_passphrase` in the example above
-  - `LAMBDA_S3_TARGET`: the name of your target bucket
-  - `LAMBDA_S3_TARGET_PATH`: (optional) The base path in your target bucket. If set, will replace the path of the rpm to sign. This
-    allows to upload the resulting signed rpm in the same bucket.
+  - `LAMBDA_S3_TARGET`: (optional) The name of the bucket where the signed RPM will be uploaded. If unset, will use the same bucket
+     as the triggering event. Please not that either one of `LAMBDA_S3_TARGET` and `LAMBDA_S3_TARGET_PATH` (or both) need to be set.
+  - `LAMBDA_S3_TARGET_PATH`: (optional) The base path in your target bucket. If set, will replace the path of the RPM to sign. This
+    allows to upload the resulting signed RPM in the same bucket as the unsigned one.
+
 ### create-repo-metadata
 
 TBD

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ aws secretsmanager create-secret --name gpg_passphrase --secret-binary file:///p
   - `LAMBDA_SECRET_GPG_KEY`: The name you used for the gpg private key aws secret, e.g. `gpg_key` in the example above
   - `LAMBDA_SECRET_GPG_PASSPHRASE`: The name you used for the gpg passphrase aws secret, e.g. `gpg_passphrase` in the example above
   - `LAMBDA_S3_TARGET`: the name of your target bucket
-
+  - `LAMBDA_S3_TARGET_PATH`: (optional) The base path in your target bucket. If set, will replace the path of the rpm to sign. This
+    allows to upload the resulting signed rpm in the same bucket.
 ### create-repo-metadata
 
 TBD


### PR DESCRIPTION
This Pull Request introduces an optional `LAMBDA_S3_TARGET_PATH`.

When set, the signed RPM is copied to `LAMBDA_S3_TARGET`:/`LAMBDA_S3_TARGET_PATH` instead of the path of the uploaded RPM file that triggered the event calling the lambda.

This allows to copy the signed RPM to the same S3 bucket as the one where the file was uploaded. To facilitate this, `LAMBDA_S3_TARGET` can be unset if `LAMBDA_S3_TARGET_PATH` is set, in which case the S3 bucket of the event is used for the destination URL.